### PR TITLE
Tighten project structure guide messaging

### DIFF
--- a/project-context-and-rules-or-guidelines/docs/PROJECT_STRUCTURE.md
+++ b/project-context-and-rules-or-guidelines/docs/PROJECT_STRUCTURE.md
@@ -2,59 +2,83 @@
 
 ## Overview
 
-This monorepo keeps the faculty evaluation platform cohesive while leaving clear seams between the FastAPI backend, the React frontend, and cross-service automation. Each top-level area mirrors a deployment unit from the documented stack in [`actual_project_context/project_techstack.md`](../actual_project_context/project_techstack.md). The backend directory focuses on synchronous API endpoints backed by SQLAlchemy models and Redis-backed RQ workers for longer jobs. The frontend directory houses a Vite-powered React TypeScript application that renders dashboards, dynamic forms, and notification flows. A dedicated `tests` arena supports cross-cutting checks such as Selenium-powered end-to-end journeys that exercise both services together. Shared documentation, operational notes, and progress tracking live under `project-context-and-rules-or-guidelines` and `project-progress` so that every contributor can quickly find constraints, conventions, and pending follow-up work.
+This monorepo keeps the FastAPI backend, React frontend, and shared automation separated but discoverable. Top-level folders map to the deployment units in [`actual_project_context/project_techstack.md`](../actual_project_context/project_techstack.md):
 
-Keeping code in the prescribed folders matters because the stack balances synchronous HTTP handlers with background processing for AI workloads, PDF export, and CSV imports. The layout also anticipates infrastructure elements like Alembic migrations, reusable scripts, and Selenium fixtures. Grouping responsibilities this way ensures that new files land beside similar examples, dependency graphs remain manageable, and future agents can map a story to the right module without rereading the entire repository.
+- `backend/` – API, domain logic, data access, and background workers.
+- `frontend/` – Vite + React TypeScript client for dashboards and forms.
+- `tests/` – Selenium, integration, and utilities that span services.
+- `project-context-and-rules-or-guidelines/` & `project-progress/` – documentation, conventions, and active follow-ups.
+
+Keeping boundaries explicit reduces hidden dependencies and helps contributors land in the right folder quickly.
 
 ## Backend layout
 
-The backend lives in [`../../backend/`](../../backend/). The heart of the service is [`backend/app/`](../../backend/app/), which mirrors FastAPI patterns and keeps imports clean. Use [`backend/app/api/routers/`](../../backend/app/api/routers/) for route modules that register path operations on the application instance. Centralize environment configuration, security helpers (JWT utilities, password hashing, TOTP verification), and shared dependencies inside [`backend/app/core/`](../../backend/app/core/). Database orchestration belongs in [`backend/app/db/`](../../backend/app/db/), including the SQLAlchemy engine, session factories, base metadata declarations, and any seed helpers that bootstrap reference data per tenant.
+The backend in [`../../backend/`](../../backend/) follows standard FastAPI boundaries:
 
-Domain entities defined with SQLAlchemy go under [`backend/app/models/`](../../backend/app/models/), while Pydantic request and response schemas live in [`backend/app/schemas/`](../../backend/app/schemas/). Encapsulate reusable business logic, such as CSV import flows, notification fan-out, or analytics aggregations, within [`backend/app/services/`](../../backend/app/services/). Dedicated worker tasks should be stored in [`backend/app/workers/`](../../backend/app/workers/) so that RQ job definitions remain isolated from request handlers. Local inference wrappers for XLM-R sentiment analysis, KeyBERT keyword extraction, or Flan-T5 suggestion generation belong in [`backend/app/ml/`](../../backend/app/ml/). Use [`backend/app/utils/`](../../backend/app/utils/) for lightweight helpers (formatting, parsing, word-count checks) that do not deserve their own domain service.
+- [`api/routers/`](../../backend/app/api/routers/) – path operations grouped by feature area.
+- [`core/`](../../backend/app/core/) – configuration, security helpers, dependency wiring.
+- [`db/`](../../backend/app/db/) – engine setup, sessions, and data-loading helpers.
+- [`models/`](../../backend/app/models/) & [`schemas/`](../../backend/app/schemas/) – ORM entities and matching Pydantic types.
+- [`services/`](../../backend/app/services/) – reusable domain logic that coordinates data and side effects.
+- [`workers/`](../../backend/app/workers/) – RQ job definitions executed outside request/response.
+- [`ml/`](../../backend/app/ml/) – local inference wrappers.
+- [`utils/`](../../backend/app/utils/) – lightweight helpers that do not fit a feature module.
 
-Alembic state is organized under [`backend/migrations/`](../../backend/migrations/). Place the migration environment script, version files, and revision helpers here to keep schema changes traceable. Scripts that interact with the API or DB from the command line—for example, maintenance tasks, seed routines, or ad-hoc data patches—should live in [`backend/scripts/`](../../backend/scripts/). Backend-scoped tests stay in [`backend/tests/`](../../backend/tests/); use this folder for pytest modules that target routers, services, database interactions, RQ job enqueuing, or schema validation without booting the frontend. When adding fixtures that are specific to backend-only tests, prefer placing them next to the modules they support or in a `conftest.py` inside this directory.
+Keep migrations in [`backend/migrations/`](../../backend/migrations/), CLI scripts in [`backend/scripts/`](../../backend/scripts/), and backend-scoped tests in [`backend/tests/`](../../backend/tests/).
 
 ## Frontend layout
 
-The frontend application resides in [`../../frontend/`](../../frontend/). Source files sit beneath [`frontend/src/`](../../frontend/src/) to align with the Vite tooling pipeline. High-level route definitions and page-level components belong to [`frontend/src/pages/`](../../frontend/src/pages/) and [`frontend/src/routes/`](../../frontend/src/routes/), where React Router segments can map to user roles such as Student or Department Head. Shared presentational building blocks and layout primitives live in [`frontend/src/components/`](../../frontend/src/components/). Feature-oriented slices that bundle state, services, and UI for a single capability (e.g., evaluation forms, dashboards, notification center) should go into [`frontend/src/features/`](../../frontend/src/features/).
+The frontend in [`../../frontend/`](../../frontend/) keeps source under [`frontend/src/`](../../frontend/src/) with these core buckets:
 
-Encapsulate reusable hooks—such as TanStack Query wrappers, polling strategies, or React Hook Form adapters—in [`frontend/src/hooks/`](../../frontend/src/hooks/). Centralize API request utilities, fetch abstractions, and client-side DTO mappers within [`frontend/src/lib/api/`](../../frontend/src/lib/api/). Style configuration, including Tailwind extensions and shared CSS modules, fits under [`frontend/src/styles/`](../../frontend/src/styles/). TypeScript helper types and Zod schemas that are reused across pages live in [`frontend/src/types/`](../../frontend/src/types/). Frontend-specific tests, whether run by Vitest or Jest, should be stored in [`frontend/src/tests/`](../../frontend/src/tests/) so they can resolve relative imports cleanly while remaining close to the code under test. Public assets exposed by the Vite build continue to reside in [`frontend/public/`](../../frontend/public/).
+- [`pages/`](../../frontend/src/pages/) & [`routes/`](../../frontend/src/routes/) – routed views and navigation tables.
+- [`features/`](../../frontend/src/features/) – feature slices that own data fetching, state, and UI.
+- [`components/`](../../frontend/src/components/) – reusable presentation pieces.
+- [`hooks/`](../../frontend/src/hooks/) – shared hook implementations (queries, forms, polling).
+- [`lib/api/`](../../frontend/src/lib/api/) – API clients, DTO mappers, and fetch wrappers.
+- [`styles/`](../../frontend/src/styles/) – Tailwind extensions or shared CSS modules.
+- [`types/`](../../frontend/src/types/) – TypeScript helpers reused across the app.
+- [`tests/`](../../frontend/src/tests/) – Vitest/RTL suites colocated with source.
+- [`public/`](../../frontend/public/) – static assets exposed by Vite.
 
 ## Testing layout
 
-Cross-service tests have a dedicated home in [`../../tests/`](../../tests/). Use [`tests/e2e/selenium/`](../../tests/e2e/selenium/) for browser automation that walks through full workflows—logging in with seeded accounts, completing evaluations, verifying sentiment displays, or downloading exported PDFs. Keep page objects, driver utilities, and synchronization helpers together so end-to-end suites remain maintainable. Place integration scenarios that spin up only portions of the stack (for instance, API plus a fake Redis worker) in [`tests/integration/`](../../tests/integration/). Share factories, fixtures, and test data generators through [`tests/fixtures/`](../../tests/fixtures/). Common helpers such as environment bootstrappers, CLI wrappers, or Selenium capability builders live in [`tests/utils/`](../../tests/utils/).
+Cross-service tests live in [`../../tests/`](../../tests/) with familiar groupings:
 
-Pytest is the default runner per [`backend/requirements.txt`](../../backend/requirements.txt). Store `pytest.ini` or equivalent configuration at the repo root or within the relevant test folder once defined. Selenium appears in the same requirements list, so plan for WebDriver binaries or remote services when scripting end-to-end flows. Backend-only tests should continue to run via `pytest backend/tests`, while the frontend can use Vitest or React Testing Library harnesses under `frontend/src/tests`. Cross-service tests can call `pytest tests` with markers to split e2e and integration coverage. Fixtures that cross boundaries—for example, provisioning a seeded database for UI tests—should live in `tests/fixtures` and be imported from backend or frontend contexts as needed to avoid duplication.
+- [`e2e/selenium/`](../../tests/e2e/selenium/) – full browser workflows.
+- [`integration/`](../../tests/integration/) – targeted multi-service checks.
+- [`fixtures/`](../../tests/fixtures/) – shared factories and data builders.
+- [`utils/`](../../tests/utils/) – environment bootstrappers and helpers.
+
+Pytest (see [`backend/requirements.txt`](../../backend/requirements.txt)) drives backend and cross-service suites. Run `pytest backend/tests` for backend coverage, `pytest tests` for shared suites, and use Vitest or React Testing Library under `frontend/src/tests` for UI checks. Share cross-cutting fixtures from `tests/fixtures` to avoid duplication.
 
 ## Conventions & tips
 
-- Keep modules short and focused. Prefer one router or service class per file, and avoid monolithic utilities.
+- Keep modules focused—ideally one router, service, or component per file.
 - Name files after their primary export (`evaluations_router.py`, `useNotifications.ts`).
-- Collocate schemas with their functional area, but mirror table names and API responses consistently.
-- Document any non-obvious dependency (external API, third-party dataset) in README snippets next to the code using it.
-- When adding secrets or environment toggles, define them inside `backend/app/core` settings objects and reference them in workers through the same module to avoid drift.
-- Maintain Tailwind configuration in a single place and import shared class names via helper functions to keep JSX tidy.
-- Use type-safe fetch wrappers in `frontend/src/lib/api` to enforce parity with backend schemas and reduce runtime parsing errors.
-- Prefer storing long-form markdown or architecture deep dives inside `project-context-and-rules-or-guidelines/docs` to keep the code tree lightweight.
+- Collocate schemas with their functional area and mirror table names or API responses.
+- Document non-obvious dependencies (external APIs, datasets) near the code that relies on them.
+- Define secrets and environment toggles in `backend/app/core` so workers reuse the same settings.
+- Centralize Tailwind configuration and share class names through helpers to keep JSX tidy.
+- Use type-safe fetch wrappers in `frontend/src/lib/api` to align with backend schemas.
+- Keep deep-dive documentation in `project-context-and-rules-or-guidelines/docs` to lighten the code tree.
 
 ## Where new files go
 
-- New FastAPI router → [`backend/app/api/routers/`](../../backend/app/api/routers/)
+- FastAPI router → [`backend/app/api/routers/`](../../backend/app/api/routers/)
 - SQLAlchemy model or Alembic helper → [`backend/app/models/`](../../backend/app/models/) or [`backend/migrations/`](../../backend/migrations/)
-- Background RQ job → [`backend/app/workers/`](../../backend/app/workers/)
-- CSV import service or PDF generator → [`backend/app/services/`](../../backend/app/services/)
-- Shared utility or validation helper → [`backend/app/utils/`](../../backend/app/utils/)
-- React page representing a routed view → [`frontend/src/pages/`](../../frontend/src/pages/)
-- Reusable UI building block → [`frontend/src/components/`](../../frontend/src/components/)
-- Feature module coordinating data fetching and state → [`frontend/src/features/`](../../frontend/src/features/)
-- Custom React hook (query, form, polling) → [`frontend/src/hooks/`](../../frontend/src/hooks/)
-- API client wrapper → [`frontend/src/lib/api/`](../../frontend/src/lib/api/)
-- Frontend styling token or Tailwind plugin → [`frontend/src/styles/`](../../frontend/src/styles/)
-- Frontend type definitions or validation schema → [`frontend/src/types/`](../../frontend/src/types/)
-- Backend unit/integration test → [`backend/tests/`](../../backend/tests/)
-- Frontend component or hook test → [`frontend/src/tests/`](../../frontend/src/tests/)
-- Full-stack Selenium scenario → [`tests/e2e/selenium/`](../../tests/e2e/selenium/)
-- Cross-service integration check without UI → [`tests/integration/`](../../tests/integration/)
-- Shared fixtures or utilities used by multiple suites → [`tests/fixtures/`](../../tests/fixtures/) or [`tests/utils/`](../../tests/utils/)
+- Background job → [`backend/app/workers/`](../../backend/app/workers/)
+- Backend service or utility → [`backend/app/services/`](../../backend/app/services/) or [`backend/app/utils/`](../../backend/app/utils/)
+- React page or routed view → [`frontend/src/pages/`](../../frontend/src/pages/) (with routes in [`frontend/src/routes/`](../../frontend/src/routes/))
+- Feature slice → [`frontend/src/features/`](../../frontend/src/features/)
+- Shared component → [`frontend/src/components/`](../../frontend/src/components/)
+- Custom hook → [`frontend/src/hooks/`](../../frontend/src/hooks/)
+- API client → [`frontend/src/lib/api/`](../../frontend/src/lib/api/)
+- Styling token or Tailwind plugin → [`frontend/src/styles/`](../../frontend/src/styles/)
+- Shared types → [`frontend/src/types/`](../../frontend/src/types/)
+- Backend test → [`backend/tests/`](../../backend/tests/)
+- Frontend test → [`frontend/src/tests/`](../../frontend/src/tests/)
+- Selenium scenario → [`tests/e2e/selenium/`](../../tests/e2e/selenium/)
+- Cross-service test without UI → [`tests/integration/`](../../tests/integration/)
+- Shared fixture or helper → [`tests/fixtures/`](../../tests/fixtures/) or [`tests/utils/`](../../tests/utils/)
 
-Following this structure keeps the repository approachable for new contributors, makes CI automation straightforward, and aligns code with the deployment model outlined in the tech stack brief. Refer back to the project tech stack document whenever you introduce a new dependency or workflow to ensure the implementation stays lean and on-spec.
+Following this structure keeps the repository approachable, makes CI automation straightforward, and aligns code with the deployment model in the tech stack brief. Revisit the tech stack document before adding new dependencies or workflows to ensure they stay on-spec.


### PR DESCRIPTION
## Summary
- tighten the overview and section descriptions to keep guidance direct while covering key directories
- clarify backend, frontend, and shared testing buckets with concise bullet explanations
- streamline conventions and placement pointers to reduce repetition and highlight the primary actions contributors should take

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d6ed9316a48321b108c120bfe8401a